### PR TITLE
separate answers and regions resources

### DIFF
--- a/ns1/provider.go
+++ b/ns1/provider.go
@@ -35,6 +35,8 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"ns1_zone":          zoneResource(),
 			"ns1_record":        recordResource(),
+			"ns1_answer":        answerResource(),
+			"ns1_region":        regionResource(),
 			"ns1_datasource":    dataSourceResource(),
 			"ns1_datafeed":      dataFeedResource(),
 			"ns1_monitoringjob": monitoringJobResource(),
@@ -46,6 +48,9 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: ns1Configure,
 	}
 }
+
+// Global mutex for records
+var RecordMutex = NewRecordMutexKV()
 
 var ErrNoAPIKey = errors.New("ns1: could not find api key")
 

--- a/ns1/record_helper.go
+++ b/ns1/record_helper.go
@@ -1,0 +1,74 @@
+package ns1
+
+import (
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/mutexkv"
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+	"log"
+	"strconv"
+)
+
+type RecordMutexKV struct {
+	mutexkv *mutexkv.MutexKV
+	tracker map[string][]interface{}
+}
+
+func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, zone string) error {
+	log.Printf("[DEBUG] Locking Record %q", record)
+	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone
+	m.mutexkv.Lock(hashRecord)
+	m.mutexkv.Lock(record)
+	defer m.mutexkv.Unlock(record)
+
+	if recordTracker, ok := m.tracker[record]; ok {
+		for p := range recordTracker {
+			if p == i {
+				return nil
+			}
+		}
+	} else {
+		r := dns.NewRecord(zone, hashRecord, "TXT")
+		if _, err := client.Records.Create(r); err != nil {
+			return err
+		}
+	}
+
+	m.tracker[record] = append(m.tracker[record], i)
+
+	log.Printf("[DEBUG] Locked Record %q", record)
+	return nil
+}
+
+func (m *RecordMutexKV) Unlock(client *ns1.Client, i interface{}, record string, zone string) error {
+	log.Printf("[DEBUG] Unlocking Record %q", record)
+	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone
+	m.mutexkv.Lock(record)
+	defer m.mutexkv.Unlock(record)
+	defer m.mutexkv.Unlock(hashRecord)
+
+	if recordTracker, ok := m.tracker[record]; ok {
+		for t := len(recordTracker) - 1; t >= 0; t-- {
+			if recordTracker[t] == i {
+				m.tracker[record] = append(recordTracker[:t], recordTracker[t+1:]...)
+			}
+		}
+	}
+	if len(m.tracker[record]) == 0 {
+		if _, err := client.Records.Delete(zone, hashRecord, "TXT"); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("[DEBUG] Unlocked Record %q", record)
+	return nil
+}
+
+// Returns a properly initalized RecordMutexKV
+func NewRecordMutexKV() *RecordMutexKV {
+	mutexKV := mutexkv.NewMutexKV()
+	return &RecordMutexKV{
+		mutexkv: mutexKV,
+		tracker: make(map[string][]interface{}),
+	}
+}

--- a/ns1/record_helper.go
+++ b/ns1/record_helper.go
@@ -17,14 +17,14 @@ type RecordMutexKV struct {
 // Lock creates a TXT record in the given zone indicating that the given record is being altered, so that parallel
 // executions of this provider are synchronized. This is safe for use by multiple goroutines. A non-nil error is
 // returned if the TXT record cannot be created.
-func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, zone string) error {
+func (mutex *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, zone string) error {
 	log.Printf("[DEBUG] Locking Record %q", record)
 	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone
-	m.mutexkv.Lock(hashRecord)
-	m.mutexkv.Lock(record)
-	defer m.mutexkv.Unlock(record)
+	mutex.mutexkv.Lock(hashRecord)
+	mutex.mutexkv.Lock(record)
+	defer mutex.mutexkv.Unlock(record)
 
-	if recordTracker, ok := m.tracker[record]; ok {
+	if recordTracker, ok := mutex.tracker[record]; ok {
 		for p := range recordTracker {
 			if p == i {
 				return nil
@@ -37,7 +37,7 @@ func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, z
 		}
 	}
 
-	m.tracker[record] = append(m.tracker[record], i)
+	mutex.tracker[record] = append(mutex.tracker[record], i)
 
 	log.Printf("[DEBUG] Locked Record %q", record)
 	return nil
@@ -46,21 +46,21 @@ func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, z
 // Unlock removes object `i` as a holder of the TXT record lock. If no such holders are left after this, Unlock
 // deletes the TXT record. This is safe for use by multiple goroutines. A non-nil error is returned if the TXT record
 // cannot be deleted.
-func (m *RecordMutexKV) Unlock(client *ns1.Client, i interface{}, record string, zone string) error {
+func (mutex *RecordMutexKV) Unlock(client *ns1.Client, i interface{}, record string, zone string) error {
 	log.Printf("[DEBUG] Unlocking Record %q", record)
 	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone
-	m.mutexkv.Lock(record)
-	defer m.mutexkv.Unlock(record)
-	defer m.mutexkv.Unlock(hashRecord)
+	mutex.mutexkv.Lock(record)
+	defer mutex.mutexkv.Unlock(record)
+	defer mutex.mutexkv.Unlock(hashRecord)
 
-	if recordTracker, ok := m.tracker[record]; ok {
+	if recordTracker, ok := mutex.tracker[record]; ok {
 		for t := len(recordTracker) - 1; t >= 0; t-- {
 			if recordTracker[t] == i {
-				m.tracker[record] = append(recordTracker[:t], recordTracker[t+1:]...)
+				mutex.tracker[record] = append(recordTracker[:t], recordTracker[t+1:]...)
 			}
 		}
 	}
-	if len(m.tracker[record]) == 0 {
+	if len(mutex.tracker[record]) == 0 {
 		if _, err := client.Records.Delete(zone, hashRecord, "TXT"); err != nil {
 			return err
 		}

--- a/ns1/record_helper.go
+++ b/ns1/record_helper.go
@@ -14,6 +14,9 @@ type RecordMutexKV struct {
 	tracker map[string][]interface{}
 }
 
+// Lock creates a TXT record in the given zone indicating that the given record is being altered, so that parallel
+// executions of this provider are synchronized. This is safe for use by multiple goroutines. A non-nil error is
+// returned if the TXT record cannot be created.
 func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, zone string) error {
 	log.Printf("[DEBUG] Locking Record %q", record)
 	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone
@@ -40,6 +43,9 @@ func (m *RecordMutexKV) Lock(client *ns1.Client, i interface{}, record string, z
 	return nil
 }
 
+// Unlock removes object `i` as a holder of the TXT record lock. If no such holders are left after this, Unlock
+// deletes the TXT record. This is safe for use by multiple goroutines. A non-nil error is returned if the TXT record
+// cannot be deleted.
 func (m *RecordMutexKV) Unlock(client *ns1.Client, i interface{}, record string, zone string) error {
 	log.Printf("[DEBUG] Unlocking Record %q", record)
 	hashRecord := strconv.Itoa(hashcode.String(record)) + "." + zone

--- a/ns1/resource_answer.go
+++ b/ns1/resource_answer.go
@@ -45,26 +45,26 @@ func answerResource() *schema.Resource {
 	}
 }
 
-func answerToResourceData(d *schema.ResourceData, a *dns.Answer) error {
+func answerToResourceData(resourceData *schema.ResourceData, a *dns.Answer) error {
 	m := answerToMap(*a)
-	d.Set("answer", m["answer"])
+	resourceData.Set("answer", m["answer"])
 	if a.RegionName != "" {
-		d.Set("region", m["region"])
+		resourceData.Set("region", m["region"])
 	}
 	if a.Meta != nil {
-		d.Set("meta", m["meta"])
+		resourceData.Set("meta", m["meta"])
 	}
-	d.SetId(answerIDHash(d))
+	resourceData.SetId(answerIDHash(resourceData))
 	return nil
 }
 
-func resourceDataToAnswer(a *dns.Answer, d *schema.ResourceData, old bool) error {
+func resourceDataToAnswer(a *dns.Answer, resourceData *schema.ResourceData, old bool) error {
 	var answer string
 	var region string
 	var meta map[string]interface{}
-	oldAnswer, newAnswer := d.GetChange("answer")
-	oldRegion, newRegion := d.GetChange("region")
-	oldMeta, newMeta := d.GetChange("meta")
+	oldAnswer, newAnswer := resourceData.GetChange("answer")
+	oldRegion, newRegion := resourceData.GetChange("region")
+	oldMeta, newMeta := resourceData.GetChange("meta")
 	if old {
 		answer = oldAnswer.(string)
 		region = oldRegion.(string)
@@ -111,19 +111,19 @@ func findRecordByAnswer(client *ns1.Client, domain string) (*dns.Record, error) 
 	return nil, fmt.Errorf("record not found: %s", domain)
 }
 
-func findAnswer(d *schema.ResourceData, r *dns.Record, old bool) (*dns.Answer, error) {
+func findAnswer(resourceData *schema.ResourceData, record *dns.Record, old bool) (*dns.Answer, error) {
 	var answer *dns.Answer
-	a := d.Get("answer").(string)
-	switch r.Type {
+	a := resourceData.Get("answer").(string)
+	switch record.Type {
 	case "TXT", "SPF":
 		answer = dns.NewTXTAnswer(a)
 	default:
 		answer = dns.NewAnswer(strings.Split(a, " "))
 	}
-	if err := resourceDataToAnswer(answer, d, true); err != nil {
+	if err := resourceDataToAnswer(answer, resourceData, true); err != nil {
 		return nil, err
 	}
-	for _, a := range r.Answers {
+	for _, a := range record.Answers {
 		if a.String() != answer.String() {
 			continue
 		}
@@ -138,83 +138,83 @@ func findAnswer(d *schema.ResourceData, r *dns.Record, old bool) (*dns.Answer, e
 	return nil, nil
 }
 
-func updateRecordForAnswer(op string, meta interface{}, d *schema.ResourceData) (*dns.Answer, error) {
+func updateRecordForAnswer(op string, meta interface{}, resourceData *schema.ResourceData) (*dns.Answer, error) {
 	client := meta.(*ns1.Client)
-	var a *dns.Answer
+	var answer *dns.Answer
 	// get the record to get the zone before creating lock
-	r, err := findRecordByAnswer(client, d.Get("record").(string))
+	record, err := findRecordByAnswer(client, resourceData.Get("record").(string))
 	if err != nil {
 		return nil, err
 	}
-	err = RecordMutex.Lock(client, a, d.Get("record").(string), r.Zone)
+	err = RecordMutex.Lock(client, answer, resourceData.Get("record").(string), record.Zone)
 	if err != nil {
 		return nil, err
 	}
-	defer RecordMutex.Unlock(client, a, d.Get("record").(string), r.Zone)
+	defer RecordMutex.Unlock(client, answer, resourceData.Get("record").(string), record.Zone)
 	// get the record again after creating lock
-	r, err = findRecordByAnswer(client, d.Get("record").(string))
+	record, err = findRecordByAnswer(client, resourceData.Get("record").(string))
 	if err != nil {
 		return nil, err
 	}
-	switch r.Type {
+	switch record.Type {
 	case "TXT", "SPF":
-		a = dns.NewTXTAnswer(d.Get("answer").(string))
+		answer = dns.NewTXTAnswer(resourceData.Get("answer").(string))
 	default:
-		a = dns.NewAnswer(strings.Split(d.Get("answer").(string), " "))
+		answer = dns.NewAnswer(strings.Split(resourceData.Get("answer").(string), " "))
 	}
-	if err := resourceDataToAnswer(a, d, false); err != nil {
+	if err := resourceDataToAnswer(answer, resourceData, false); err != nil {
 		return nil, err
 	}
 	switch op {
 	case "create":
 		// Create the answer
-		r.AddAnswer(a)
-		if _, err := client.Records.Update(r); err != nil {
+		record.AddAnswer(answer)
+		if _, err := client.Records.Update(record); err != nil {
 			return nil, err
 		}
 	case "update":
-		old, err := findAnswer(d, r, true)
+		old, err := findAnswer(resourceData, record, true)
 		if err != nil {
 			return nil, err
 		}
 		// Replace the answer
-		for i := 0; i < len(r.Answers); i++ {
-			if r.Answers[i] == old {
-				r.Answers[i] = a
+		for i := 0; i < len(record.Answers); i++ {
+			if record.Answers[i] == old {
+				record.Answers[i] = answer
 				break
 			}
 		}
-		if _, err := client.Records.Update(r); err != nil {
+		if _, err := client.Records.Update(record); err != nil {
 			return nil, err
 		}
 	case "delete":
-		old, err := findAnswer(d, r, false)
+		old, err := findAnswer(resourceData, record, false)
 		if err != nil {
 			return nil, err
 		}
 		// Delete the answer
-		for i := len(r.Answers) - 1; i >= 0; i-- {
-			if r.Answers[i] == old {
-				r.Answers = append(r.Answers[:i], r.Answers[i+1:]...)
+		for i := len(record.Answers) - 1; i >= 0; i-- {
+			if record.Answers[i] == old {
+				record.Answers = append(record.Answers[:i], record.Answers[i+1:]...)
 			}
 		}
-		if _, err := client.Records.Update(r); err != nil {
+		if _, err := client.Records.Update(record); err != nil {
 			return nil, err
 		}
-		d.SetId("")
+		resourceData.SetId("")
 	}
-	return a, nil
+	return answer, nil
 }
 
-func answerIDHash(d *schema.ResourceData) string {
+func answerIDHash(resourceData *schema.ResourceData) string {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%s-", d.Get("record").(string)))
-	buf.WriteString(fmt.Sprintf("%s-", d.Get("answer").(string)))
-	if d.Get("region").(string) != "" {
-		buf.WriteString(fmt.Sprintf("%s-", d.Get("region").(string)))
+	buf.WriteString(fmt.Sprintf("%s-", resourceData.Get("record").(string)))
+	buf.WriteString(fmt.Sprintf("%s-", resourceData.Get("answer").(string)))
+	if resourceData.Get("region").(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", resourceData.Get("region").(string)))
 	}
-	if d.Get("meta").(map[string]interface{}) != nil {
-		for k, v := range d.Get("meta").(map[string]interface{}) {
+	if resourceData.Get("meta").(map[string]interface{}) != nil {
+		for k, v := range resourceData.Get("meta").(map[string]interface{}) {
 			buf.WriteString(fmt.Sprintf("%s-%s-", k, v))
 		}
 	}
@@ -222,38 +222,38 @@ func answerIDHash(d *schema.ResourceData) string {
 }
 
 // AnswerCreate creates answer for given record in ns1
-func AnswerCreate(d *schema.ResourceData, meta interface{}) error {
-	a, err := updateRecordForAnswer("create", meta, d)
+func AnswerCreate(resourceData *schema.ResourceData, meta interface{}) error {
+	a, err := updateRecordForAnswer("create", meta, resourceData)
 	if err != nil {
 		return err
 	}
-	return answerToResourceData(d, a)
+	return answerToResourceData(resourceData, a)
 }
 
 // AnswerRead reads the answer for given record from ns1
-func AnswerRead(d *schema.ResourceData, meta interface{}) error {
+func AnswerRead(resourceData *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ns1.Client)
-	r, err := findRecordByAnswer(client, d.Get("record").(string))
+	r, err := findRecordByAnswer(client, resourceData.Get("record").(string))
 	if err != nil {
 		if !strings.Contains(err.Error(), "record not found") {
 			return err
 		}
 	}
-	a, err := findAnswer(d, r, false)
+	a, err := findAnswer(resourceData, r, false)
 	if err != nil {
 		return err
 	}
 	// Could not find answer
 	if a == nil {
-		d.SetId("")
+		resourceData.SetId("")
 		return nil
 	}
-	return answerToResourceData(d, a)
+	return answerToResourceData(resourceData, a)
 }
 
 // AnswerDelete deletes the answer from the record from ns1
-func AnswerDelete(d *schema.ResourceData, meta interface{}) error {
-	_, err := updateRecordForAnswer("delete", meta, d)
+func AnswerDelete(resourceData *schema.ResourceData, meta interface{}) error {
+	_, err := updateRecordForAnswer("delete", meta, resourceData)
 	if err != nil {
 		return err
 	}
@@ -261,10 +261,10 @@ func AnswerDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 // AnswerUpdate updates the given answer in the record in ns1
-func AnswerUpdate(d *schema.ResourceData, meta interface{}) error {
-	a, err := updateRecordForAnswer("update", meta, d)
+func AnswerUpdate(resourceData *schema.ResourceData, meta interface{}) error {
+	a, err := updateRecordForAnswer("update", meta, resourceData)
 	if err != nil {
 		return err
 	}
-	return answerToResourceData(d, a)
+	return answerToResourceData(resourceData, a)
 }

--- a/ns1/resource_answer.go
+++ b/ns1/resource_answer.go
@@ -1,0 +1,270 @@
+package ns1
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/data"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func answerResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required
+			"record": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"answer": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Optional
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"meta": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+		},
+		Create: AnswerCreate,
+		Read:   AnswerRead,
+		Update: AnswerUpdate,
+		Delete: AnswerDelete,
+	}
+}
+
+func answerToResourceData(d *schema.ResourceData, a *dns.Answer) error {
+	m := answerToMap(*a)
+	d.Set("answer", m["answer"])
+	if a.RegionName != "" {
+		d.Set("region", m["region"])
+	}
+	if a.Meta != nil {
+		d.Set("meta", m["meta"])
+	}
+	d.SetId(answerIDHash(d))
+	return nil
+}
+
+func resourceDataToAnswer(a *dns.Answer, d *schema.ResourceData, old bool) error {
+	var answer string
+	var region string
+	var meta map[string]interface{}
+	oldAnswer, newAnswer := d.GetChange("answer")
+	oldRegion, newRegion := d.GetChange("region")
+	oldMeta, newMeta := d.GetChange("meta")
+	if old {
+		answer = oldAnswer.(string)
+		region = oldRegion.(string)
+		meta = oldMeta.(map[string]interface{})
+	} else {
+		answer = newAnswer.(string)
+		region = newRegion.(string)
+		meta = newMeta.(map[string]interface{})
+	}
+	a.Rdata = strings.Split(answer, " ")
+	if region != "" {
+		a.RegionName = region
+	}
+	if meta != nil {
+		a.Meta = data.MetaFromMap(meta)
+		errs := a.Meta.Validate()
+		if len(errs) > 0 {
+			return errJoin(append([]error{errors.New("found error/s in answer metadata")}, errs...), ",")
+		}
+	}
+	return nil
+}
+
+func findRecordByAnswer(client *ns1.Client, domain string) (*dns.Record, error) {
+	zones, _, err := client.Zones.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, z := range zones {
+		zone, _, err := client.Zones.Get(z.Zone)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range zone.Records {
+			if domain == record.Domain {
+				r, _, err := client.Records.Get(z.Zone, record.Domain, record.Type)
+				if err != nil {
+					return nil, err
+				}
+				return r, err
+			}
+		}
+	}
+	return nil, fmt.Errorf("record not found: %s", domain)
+}
+
+func findAnswer(d *schema.ResourceData, r *dns.Record, old bool) (*dns.Answer, error) {
+	var answer *dns.Answer
+	a := d.Get("answer").(string)
+	switch r.Type {
+	case "TXT", "SPF":
+		answer = dns.NewTXTAnswer(a)
+	default:
+		answer = dns.NewAnswer(strings.Split(a, " "))
+	}
+	if err := resourceDataToAnswer(answer, d, true); err != nil {
+		return nil, err
+	}
+	for _, a := range r.Answers {
+		if a.String() != answer.String() {
+			continue
+		}
+		if a.RegionName != answer.RegionName {
+			continue
+		}
+		if !reflect.DeepEqual(a.Meta.StringMap(), answer.Meta.StringMap()) {
+			continue
+		}
+		return a, nil
+	}
+	return nil, nil
+}
+
+func updateRecordForAnswer(op string, meta interface{}, d *schema.ResourceData) (*dns.Answer, error) {
+	client := meta.(*ns1.Client)
+	var a *dns.Answer
+	// get the record to get the zone before creating lock
+	r, err := findRecordByAnswer(client, d.Get("record").(string))
+	if err != nil {
+		return nil, err
+	}
+	err = RecordMutex.Lock(client, a, d.Get("record").(string), r.Zone)
+	if err != nil {
+		return nil, err
+	}
+	defer RecordMutex.Unlock(client, a, d.Get("record").(string), r.Zone)
+	// get the record again after creating lock
+	r, err = findRecordByAnswer(client, d.Get("record").(string))
+	if err != nil {
+		return nil, err
+	}
+	switch r.Type {
+	case "TXT", "SPF":
+		a = dns.NewTXTAnswer(d.Get("answer").(string))
+	default:
+		a = dns.NewAnswer(strings.Split(d.Get("answer").(string), " "))
+	}
+	if err := resourceDataToAnswer(a, d, false); err != nil {
+		return nil, err
+	}
+	switch op {
+	case "create":
+		// Create the answer
+		r.AddAnswer(a)
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+	case "update":
+		old, err := findAnswer(d, r, true)
+		if err != nil {
+			return nil, err
+		}
+		// Replace the answer
+		for i := 0; i < len(r.Answers); i++ {
+			if r.Answers[i] == old {
+				r.Answers[i] = a
+				break
+			}
+		}
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+	case "delete":
+		old, err := findAnswer(d, r, false)
+		if err != nil {
+			return nil, err
+		}
+		// Delete the answer
+		for i := len(r.Answers) - 1; i >= 0; i-- {
+			if r.Answers[i] == old {
+				r.Answers = append(r.Answers[:i], r.Answers[i+1:]...)
+			}
+		}
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+		d.SetId("")
+	}
+	return a, nil
+}
+
+func answerIDHash(d *schema.ResourceData) string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", d.Get("record").(string)))
+	buf.WriteString(fmt.Sprintf("%s-", d.Get("answer").(string)))
+	if d.Get("region").(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", d.Get("region").(string)))
+	}
+	if d.Get("meta").(map[string]interface{}) != nil {
+		for k, v := range d.Get("meta").(map[string]interface{}) {
+			buf.WriteString(fmt.Sprintf("%s-%s-", k, v))
+		}
+	}
+	return fmt.Sprintf("ans-%d", hashcode.String(buf.String()))
+}
+
+// AnswerCreate creates answer for given record in ns1
+func AnswerCreate(d *schema.ResourceData, meta interface{}) error {
+	a, err := updateRecordForAnswer("create", meta, d)
+	if err != nil {
+		return err
+	}
+	return answerToResourceData(d, a)
+}
+
+// AnswerRead reads the answer for given record from ns1
+func AnswerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ns1.Client)
+	r, err := findRecordByAnswer(client, d.Get("record").(string))
+	if err != nil {
+		if !strings.Contains(err.Error(), "record not found") {
+			return err
+		}
+	}
+	a, err := findAnswer(d, r, false)
+	if err != nil {
+		return err
+	}
+	// Could not find answer
+	if a == nil {
+		d.SetId("")
+		return nil
+	}
+	return answerToResourceData(d, a)
+}
+
+// AnswerDelete deletes the answer from the record from ns1
+func AnswerDelete(d *schema.ResourceData, meta interface{}) error {
+	_, err := updateRecordForAnswer("delete", meta, d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// AnswerUpdate updates the given answer in the record in ns1
+func AnswerUpdate(d *schema.ResourceData, meta interface{}) error {
+	a, err := updateRecordForAnswer("update", meta, d)
+	if err != nil {
+		return err
+	}
+	return answerToResourceData(d, a)
+}

--- a/ns1/resource_region.go
+++ b/ns1/resource_region.go
@@ -1,0 +1,267 @@
+package ns1
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/data"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
+)
+
+func regionResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Required
+			"record": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// Optional
+			"meta": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+		},
+		Create: RegionCreate,
+		Read:   RegionRead,
+		Update: RegionUpdate,
+		Delete: RegionDelete,
+	}
+}
+
+// Get Region from Regions
+func getRegion(r data.Regions) (string, *data.Region) {
+	var name string
+	var region *data.Region
+	for k, v := range r {
+		name = k
+		region = &v
+		break
+	}
+	return name, region
+}
+
+func regionToMap(regions data.Regions) map[string]interface{} {
+	m := make(map[string]interface{})
+	name, region := getRegion(regions)
+	m["name"] = name
+	if region != nil {
+		m["meta"] = region.Meta.StringMap()
+	}
+	return m
+}
+
+func regionsToResourceData(d *schema.ResourceData, regions data.Regions) error {
+	m := regionToMap(regions)
+	d.Set("name", m["name"])
+	if m["meta"] != nil {
+		d.Set("meta", m["meta"])
+	}
+	d.SetId(regionIDHash(d))
+	return nil
+}
+
+func resourceDataToRegions(regions data.Regions, d *schema.ResourceData, old bool) error {
+	var name string
+	var meta map[string]interface{}
+	oldName, newName := d.GetChange("name")
+	oldMeta, newMeta := d.GetChange("meta")
+	if old {
+		name = oldName.(string)
+		meta = oldMeta.(map[string]interface{})
+	} else {
+		name = newName.(string)
+		meta = newMeta.(map[string]interface{})
+	}
+	var region data.Region
+	if meta != nil {
+		region.Meta = *data.MetaFromMap(meta)
+		errs := region.Meta.Validate()
+		if len(errs) > 0 {
+			return errJoin(append([]error{errors.New("found error/s in region metadata")}, errs...), ",")
+		}
+	}
+	regions[name] = region
+	return nil
+}
+
+func findRecordByRegion(client *ns1.Client, domain string) (*dns.Record, error) {
+	zones, _, err := client.Zones.List()
+	if err != nil {
+		return nil, err
+	}
+	for _, z := range zones {
+		zone, _, err := client.Zones.Get(z.Zone)
+		if err != nil {
+			return nil, err
+		}
+		for _, record := range zone.Records {
+			if domain == record.Domain {
+				r, _, err := client.Records.Get(z.Zone, record.Domain, record.Type)
+				if err != nil {
+					return nil, err
+				}
+				return r, err
+			}
+		}
+	}
+	return nil, fmt.Errorf("record not found: %s", domain)
+}
+
+func findRegion(d *schema.ResourceData, record *dns.Record, old bool) (data.Regions, error) {
+	var regions = data.Regions{}
+	if err := resourceDataToRegions(regions, d, true); err != nil {
+		return nil, err
+	}
+	name, _ := getRegion(regions)
+	for k, v := range record.Regions {
+		if k != name {
+			continue
+		}
+		regions[k] = v
+		return regions, nil
+	}
+	return nil, nil
+}
+
+func updateRecordForRegion(op string, meta interface{}, d *schema.ResourceData) (data.Regions, error) {
+	client := meta.(*ns1.Client)
+	var regions = data.Regions{}
+	// get the record to get the zone before creating lock
+	r, err := findRecordByRegion(client, d.Get("record").(string))
+	if err != nil {
+		return nil, err
+	}
+	err = RecordMutex.Lock(client, &regions, d.Get("record").(string), r.Zone)
+	if err != nil {
+		return nil, err
+	}
+	defer RecordMutex.Unlock(client, &regions, d.Get("record").(string), r.Zone)
+	// get the record again after creating lock
+	r, err = findRecordByRegion(client, d.Get("record").(string))
+	if err != nil {
+		return nil, err
+	}
+	if err := resourceDataToRegions(regions, d, false); err != nil {
+		return nil, err
+	}
+	switch op {
+	case "create":
+		// Create the region
+		region := data.Region{
+			Meta: data.Meta{},
+		}
+		meta := data.MetaFromMap(d.Get("meta").(map[string]interface{}))
+		region.Meta = *meta
+		errs := region.Meta.Validate()
+		if len(errs) > 0 {
+			return nil, errJoin(append([]error{errors.New("found error/s in region metadata")}, errs...), ",")
+		}
+		r.Regions[d.Get("name").(string)] = region
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+		regions[d.Get("name").(string)] = region
+	case "update":
+		_, err := findRegion(d, r, true)
+		if err != nil {
+			return nil, err
+		}
+		// Replace the region
+		region := r.Regions[d.Get("name").(string)]
+		meta := data.MetaFromMap(d.Get("meta").(map[string]interface{}))
+		region.Meta = *meta
+		errs := region.Meta.Validate()
+		if len(errs) > 0 {
+			return nil, errJoin(append([]error{errors.New("found error/s in region metadata")}, errs...), ",")
+		}
+		r.Regions[d.Get("name").(string)] = region
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+		regions[d.Get("name").(string)] = region
+	case "delete":
+		_, err := findRegion(d, r, false)
+		if err != nil {
+			return nil, err
+		}
+		// Delete the region
+		delete(r.Regions, d.Get("name").(string))
+		if _, err := client.Records.Update(r); err != nil {
+			return nil, err
+		}
+		d.SetId("")
+	}
+	return regions, nil
+}
+
+func regionIDHash(d *schema.ResourceData) string {
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", d.Get("record").(string)))
+	buf.WriteString(fmt.Sprintf("%s-", d.Get("name").(string)))
+	if d.Get("meta").(map[string]interface{}) != nil {
+		for k, v := range d.Get("meta").(map[string]interface{}) {
+			buf.WriteString(fmt.Sprintf("%s-%s-", k, v))
+		}
+	}
+	return fmt.Sprintf("reg-%d", hashcode.String(buf.String()))
+}
+
+// RegionCreate creates region for given record in ns1
+func RegionCreate(d *schema.ResourceData, meta interface{}) error {
+	regions, err := updateRecordForRegion("create", meta, d)
+	if err != nil {
+		return err
+	}
+	return regionsToResourceData(d, regions)
+}
+
+// RegionRead reads the region for given record from ns1
+func RegionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ns1.Client)
+	r, err := findRecordByRegion(client, d.Get("record").(string))
+	if err != nil {
+		if !strings.Contains(err.Error(), "record not found") {
+			return err
+		}
+	}
+	region, err := findRegion(d, r, false)
+	if err != nil {
+		return err
+	}
+	// Could not find region
+	if region == nil {
+		d.SetId("")
+		return nil
+	}
+	return regionsToResourceData(d, region)
+}
+
+// RegionDelete deletes the region from the record from ns1
+func RegionDelete(d *schema.ResourceData, meta interface{}) error {
+	_, err := updateRecordForRegion("delete", meta, d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RegionUpdate updates the given region in the record in ns1
+func RegionUpdate(d *schema.ResourceData, meta interface{}) error {
+	region, err := updateRecordForRegion("update", meta, d)
+	if err != nil {
+		return err
+	}
+	return regionsToResourceData(d, region)
+}

--- a/ns1/resource_region.go
+++ b/ns1/resource_region.go
@@ -163,6 +163,9 @@ func updateRecordForRegion(op string, meta interface{}, d *schema.ResourceData) 
 			Meta: data.Meta{},
 		}
 		meta := data.MetaFromMap(d.Get("meta").(map[string]interface{}))
+		if meta == nil {
+			return nil, errors.New("could not read metadata")
+		}
 		region.Meta = *meta
 		errs := region.Meta.Validate()
 		if len(errs) > 0 {
@@ -181,6 +184,9 @@ func updateRecordForRegion(op string, meta interface{}, d *schema.ResourceData) 
 		// Replace the region
 		region := r.Regions[d.Get("name").(string)]
 		meta := data.MetaFromMap(d.Get("meta").(map[string]interface{}))
+		if meta == nil {
+			return nil, errors.New("could not read metadata")
+		}
 		region.Meta = *meta
 		errs := region.Meta.Validate()
 		if len(errs) > 0 {


### PR DESCRIPTION
In order to manage `answers` and `regions` separately from `records`, introduce the ability to define ns1 answers and regions as separate Terraform resources.

This should allow you to do things like:
  1. save/maintain the answer/region of a record in a separate TF state file
  1. introduce the ability to programmatically add and remove answers/regions (via something like TF's `count` parameter)

The main challenge (and the reason that this would be very much considered a hack) was to get Terraform to maintain answers and regions as separate resources while _safely_ updating records, answers, and regions via the NS1 API, since, from NS1's perspective, answers and regions are simply parameters within the json blob that contains everything about the record.

This meant introducing some sort of locking mechanism. The locking itself is very hacky, as we're utilizing the zone to create a temporary record as the lock. In addition, there is another lock to ensure that Terraform does not perform concurrent updates on a record, within one `apply` operation.

Example Usage
==

```hcl
resource "ns1_record" "rec3" {
  domain = "test3.serverless.farm"
  zone   = "serverless.farm"
  type   = "A"
  ttl    = 300

  lifecycle {
    ignore_changes = ["regions", "answers"]
  }
}

resource "ns1_answer" "ble_3" {
  record = "${ns1_record.rec3.domain}"
  answer = "10.5.0.6"
  region = "${ns1_region.ec2-us-east-1_3.name}"

  meta {
    up = "1"
  }
}

resource "ns1_region" "ec2-us-east-1_3" {
  record = "${ns1_record.rec3.domain}"
  name = "ec2-us-east-1"

  meta {
    us_state = "VA"
  }
}
```